### PR TITLE
Hash-style context accessors

### DIFF
--- a/benchmarks/context.rb
+++ b/benchmarks/context.rb
@@ -1,0 +1,16 @@
+require 'benchmark/ips'
+require 'cooperator'
+
+context = Cooperator::Context.new value: 1
+
+Benchmark.ips do |bm|
+  bm.report '#method_missing' do
+    context.value
+  end
+
+  bm.report '#[]' do
+    context[:value]
+  end
+
+  bm.compare!
+end

--- a/cooperator.gemspec
+++ b/cooperator.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', "~> 1.5"
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'benchmark-ips'
 end

--- a/lib/cooperator.rb
+++ b/lib/cooperator.rb
@@ -111,7 +111,7 @@ module Cooperator
 
   def commit(properties = {})
     properties.each do |key, value|
-      context.send :"#{key}=", value
+      context[key] = value
     end
   end
 

--- a/lib/cooperator.rb
+++ b/lib/cooperator.rb
@@ -30,7 +30,7 @@ module Cooperator
     def accepts(property, default: nil)
       define_method property do
         if context.include? property
-          value = context.send property
+          value = context[property]
           value.is_a?(Proc) ? value.call : value
         else
           nil

--- a/lib/cooperator.rb
+++ b/lib/cooperator.rb
@@ -21,7 +21,7 @@ module Cooperator
 
     def expects(property)
       define_method property do
-        context.send property
+        context[property]
       end
 
       expected << property

--- a/lib/cooperator/context.rb
+++ b/lib/cooperator/context.rb
@@ -4,7 +4,7 @@ module Cooperator
       @_attributes = {_failure: false}
 
       attributes.each do |k, v|
-        send :"#{k}=", v
+        self[k] = v
       end
     end
 

--- a/lib/cooperator/context.rb
+++ b/lib/cooperator/context.rb
@@ -36,6 +36,10 @@ module Cooperator
       @_attributes.include? key
     end
 
+    def [](key)
+      @_attributes[key]
+    end
+
     def method_missing(method, *args, &block)
       return @_attributes.fetch method if @_attributes.include? method
 

--- a/lib/cooperator/context.rb
+++ b/lib/cooperator/context.rb
@@ -21,7 +21,7 @@ module Cooperator
         errors[key].push message
       end
 
-      self._failure = true
+      self[:_failure] = true
     end
 
     def success?

--- a/lib/cooperator/context.rb
+++ b/lib/cooperator/context.rb
@@ -13,7 +13,7 @@ module Cooperator
     end
 
     def success!
-      self._failure = false
+      self[:_failure] = false
     end
 
     def failure!(messages = {})

--- a/lib/cooperator/context.rb
+++ b/lib/cooperator/context.rb
@@ -36,6 +36,10 @@ module Cooperator
       @_attributes.include? key
     end
 
+    def []=(key, value)
+      @_attributes[key] = value
+    end
+
     def [](key)
       @_attributes[key]
     end

--- a/lib/cooperator/context.rb
+++ b/lib/cooperator/context.rb
@@ -45,11 +45,18 @@ module Cooperator
     end
 
     def method_missing(method, *args, &block)
-      return @_attributes.fetch method if @_attributes.include? method
+      if @_attributes.include? method
+        puts Kernel.caller.first
+        warn '[DEPRECATED] Cooperator::Context: Use hash-style accessors instead of methods.'
+
+        return @_attributes.fetch method
+      end
 
       name = String method
 
       if name.include? '='
+        warn '[DEPRECATED] Cooperator::Context: Use hash-style accessors instead of methods.'
+
         name.gsub!(/=/, '')
 
         @_attributes[:"#{name}"] = args.shift

--- a/lib/cooperator/context.rb
+++ b/lib/cooperator/context.rb
@@ -29,7 +29,7 @@ module Cooperator
     end
 
     def failure?
-      _failure
+      self[:_failure]
     end
 
     def include?(key)


### PR DESCRIPTION
In line with #17, let's introduce hash-style context accessors:

```
context[:value] = 1
context[:value]
```

Method-style accessors are being deprecated in favor of the former, which is more performant:

```
context.value = 1 #=> [DEPRECATED] Cooperator::Context: Use hash-style accessors instead of methods.
context.value     #=> [DEPRECATED] Cooperator::Context: Use hash-style accessors instead of methods.
```

Lastly, let's use these new accessors inside Cooperator objects and methods, including the `expected`, `accepted` and `commit` directives.